### PR TITLE
Support End Gateway as gate material

### DIFF
--- a/AncientGates/src/org/mcteam/ancientgates/Gates.java
+++ b/AncientGates/src/org/mcteam/ancientgates/Gates.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.bukkit.Material;
 import org.bukkit.block.Biome;
 import org.bukkit.block.BlockState;
+import org.bukkit.block.EndGateway;
 import org.bukkit.material.MaterialData;
 import org.mcteam.ancientgates.util.BlockUtil;
 import org.mcteam.ancientgates.util.types.FloodOrientation;
@@ -115,6 +116,27 @@ public class Gates {
 			}
 
 			coord.getBlock().setType(material);
+
+			if (material == Material.END_GATEWAY) {
+				EndGateway eg = (EndGateway) coord.getBlock().getState();
+
+				// Prevent beams appearing every 2400 ticks by assigning them
+				// the lowest possible negative age (see MC-107824)
+				eg.setAge(Long.MIN_VALUE);
+
+				// We need to know the location of the End Gateway block that
+				// triggers a PlayerTeleportEvent to figure out whether that
+				// event is gate-related, but this information isn't provided to
+				// the event handler, even when the cause is the player coming
+				// into contact with an End Gateway block - work around this by
+				// making the End Gateway block teleport to itself, so the
+				// teleportation destination becomes a proxy for the block's
+				// location
+				eg.setExitLocation(coord.getLocation());
+				eg.setExactTeleport(true);
+
+				eg.update(true);
+			}
 
 			// Stop ice forming based on biome (horizontal water portals)
 			if (orientation == FloodOrientation.HORIZONTAL && gate.getMaterial() == Material.WATER) {

--- a/AncientGates/src/org/mcteam/ancientgates/Plugin.java
+++ b/AncientGates/src/org/mcteam/ancientgates/Plugin.java
@@ -197,8 +197,8 @@ public class Plugin extends JavaPlugin {
 		commands.add(new CommandSetEntities());
 		if (!Conf.useVanillaPortals) {
 			commands.add(new CommandSetVehicles());
-			commands.add(new CommandSetMaterial());
 		}
+		commands.add(new CommandSetMaterial());
 		commands.add(new CommandSetInventory());
 		commands.add(new CommandTeleportFrom());
 		commands.add(new CommandTeleportTo());

--- a/AncientGates/src/org/mcteam/ancientgates/commands/base/CommandHelp.java
+++ b/AncientGates/src/org/mcteam/ancientgates/commands/base/CommandHelp.java
@@ -54,8 +54,7 @@ public class CommandHelp extends BaseCommand {
 		lines.add(new CommandCreate().getUsageTemplate(true, true));
 		lines.add(new CommandSetFrom().getUsageTemplate(true, true));
 		lines.add(new CommandSetTo().getUsageTemplate(true, true));
-		if (!Conf.useVanillaPortals)
-			lines.add(new CommandSetMaterial().getUsageTemplate(true, true));
+		lines.add(new CommandSetMaterial().getUsageTemplate(true, true));
 		lines.add(new CommandOpen().getUsageTemplate(true, true));
 		lines.add(new CommandClose().getUsageTemplate(true, true));
 		lines.add(new CommandDelete().getUsageTemplate(true, true));

--- a/AncientGates/src/org/mcteam/ancientgates/commands/base/CommandSetMaterial.java
+++ b/AncientGates/src/org/mcteam/ancientgates/commands/base/CommandSetMaterial.java
@@ -28,9 +28,12 @@ public class CommandSetMaterial extends BaseCommand {
 	public void perform() {
 		final String material = parameters.get(1).toUpperCase();
 
-		if (GateMaterial.fromName(material) == null) {
+		// Whether the given gate material is valid depends on whether only
+		// vanilla portal blocks are allowed:
+		final GateMaterial materialFromName = GateMaterial.fromName(material);
+		if (materialFromName == null || (Conf.useVanillaPortals && !materialFromName.isVanilla())) {
 			sendMessage("This is not a valid gate material. Valid materials:");
-			sendMessage(TextUtil.implode(Arrays.asList(GateMaterial.names), Conf.colorSystem + ", "));
+			sendMessage(TextUtil.implode(Arrays.asList(Conf.useVanillaPortals ? GateMaterial.vanillaNames : GateMaterial.names), Conf.colorSystem + ", "));
 			return;
 		}
 

--- a/AncientGates/src/org/mcteam/ancientgates/listeners/PluginEntityListener.java
+++ b/AncientGates/src/org/mcteam/ancientgates/listeners/PluginEntityListener.java
@@ -12,6 +12,7 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityPortalEvent;
+import org.bukkit.event.entity.EntityTeleportEvent;
 import org.mcteam.ancientgates.Conf;
 import org.mcteam.ancientgates.Gate;
 import org.mcteam.ancientgates.Plugin;
@@ -25,6 +26,27 @@ public class PluginEntityListener implements Listener {
 
 	public PluginEntityListener(final Plugin plugin) {
 		this.plugin = plugin;
+	}
+
+	/*
+	 * All entities are currently forbidden from teleporting via End
+	 * Gateway-based gates - this is an arbitrary restriction imposed because
+	 * of the amount of code-rewriting that would be needed in order to prevent
+	 * item duplication exploits, but is at least consistent with the behavior
+	 * of Nether Portals
+	 */
+	@EventHandler(priority = EventPriority.HIGH)
+	public void onEntityTeleport(final EntityTeleportEvent event) {
+		if (event.isCancelled()) {
+			return;
+		}
+		
+		final WorldCoord entityCoord = new WorldCoord(event.getTo());
+		final Gate nearestGate = GateUtil.nearestGate(entityCoord, true);
+
+		if (nearestGate != null) {
+			event.setCancelled(true);
+		}
 	}
 
 	@EventHandler

--- a/AncientGates/src/org/mcteam/ancientgates/util/BlockUtil.java
+++ b/AncientGates/src/org/mcteam/ancientgates/util/BlockUtil.java
@@ -17,6 +17,7 @@ public class BlockUtil {
 		standableGateMaterials = new HashSet<>();
 		standableGateMaterials.add(Material.PISTON_HEAD);
 		standableGateMaterials.add(Material.END_PORTAL);
+		standableGateMaterials.add(Material.END_GATEWAY);
 		standableGateMaterials.add(Material.LAVA);
 		standableGateMaterials.add(Material.NETHER_PORTAL);
 		standableGateMaterials.add(Material.LAVA);
@@ -83,13 +84,14 @@ public class BlockUtil {
 			standableMaterials.put(Material.DAYLIGHT_DETECTOR, false); // 151 Daylight Sensor
 			standableMaterials.put(Material.ACTIVATOR_RAIL, true); // 157 Activator Rail
 			standableMaterials.put(Material.WHITE_CARPET, true); // 171 Carpet
+			standableMaterials.put(Material.END_GATEWAY, true); // 209 End Gateway
 			//standableMaterials.put(Material.DOUBLE_PLANT, true); // double_plant Double Plants
 		} catch (final NoSuchFieldError e) {
 		} // Support previous MC versions
 	}
 
 	public static boolean isPortalGateMaterial(final Material material) {
-		return material.equals(Material.NETHER_PORTAL) || material.equals(Material.END_PORTAL);
+		return material.equals(Material.NETHER_PORTAL) || material.equals(Material.END_PORTAL) || material.equals(Material.END_GATEWAY);
 	}
 
 	public static boolean isStandableGateMaterial(final Material material) {

--- a/AncientGates/src/org/mcteam/ancientgates/util/types/GateMaterial.java
+++ b/AncientGates/src/org/mcteam/ancientgates/util/types/GateMaterial.java
@@ -1,7 +1,9 @@
 package org.mcteam.ancientgates.util.types;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.bukkit.Material;
@@ -11,19 +13,22 @@ public enum GateMaterial {
 	//AIR("psudeo air blocks", Material.LEGACY_PISTON_MOVING_PIECE),
 
 	// LAVA
-	LAVA("stationary lava blocks", Material.LAVA),
+	LAVA("stationary lava blocks", Material.LAVA, false),
 
 	// NETHER/ENDER PORTAL
-	PORTAL("nether/ender portal blocks", Material.LEGACY_PORTAL),
+	PORTAL("nether/ender portal blocks", Material.LEGACY_PORTAL, true),
+
+	// END GATEWAY
+	ENDGATEWAY("End Gateway blocks", Material.END_GATEWAY, true),
 
 	// SUGARCANE
-	SUGARCANE("sugarcane blocks", Material.LEGACY_SUGAR_CANE_BLOCK),
+	SUGARCANE("sugarcane blocks", Material.LEGACY_SUGAR_CANE_BLOCK, false),
 
 	// WATER
-	WATER("stationary water blocks", Material.WATER),
+	WATER("stationary water blocks", Material.WATER, false),
 
 	// WEB
-	WEB("spiders web blocks", Material.COBWEB);
+	WEB("spiders web blocks", Material.COBWEB, false);
 
 	private static final Map<String, GateMaterial> nameToMaterial = new HashMap<>();
 
@@ -32,17 +37,24 @@ public enum GateMaterial {
 			nameToMaterial.put(value.name(), value);
 		}
 	}
-	
+
 	public static GateMaterial fromName(final String name) {
 		return nameToMaterial.get(name);
 	}
 
 	public static final String[] names = new String[values().length];
+	public static String[] vanillaNames;
 
 	static {
 		final GateMaterial[] values = values();
-		for (int i = 0; i < values.length; i++)
+		final List<String> vanillaNamesList = new ArrayList<>();
+
+		for (int i = 0; i < values.length; i++) {
 			names[i] = values[i].name();
+			if (values[i].isVanilla()) vanillaNamesList.add(values[i].name());
+		}
+
+		vanillaNames = vanillaNamesList.toArray(new String[0]);
 	}
 
 	protected final String desc;
@@ -57,9 +69,16 @@ public enum GateMaterial {
 		return this.material;
 	}
 
-	private GateMaterial(final String desc, final Material material) {
+	protected final boolean isVanilla;
+
+	public boolean isVanilla() {
+		return isVanilla;
+	}
+
+	private GateMaterial(final String desc, final Material material, final boolean isVanilla) {
 		this.desc = desc;
 		this.material = material;
+		this.isVanilla = isVanilla;
 	}
 
 }


### PR DESCRIPTION
This PR adds support for End Gateway blocks as portal blocks in gates.

End Gateway-based gates can be created using the material name `ENDGATEWAY`. Since End Gateways are basically vanilla portals (technically not quite true, but at least they don't rely on movement handlers in order to work), the `/gate setmaterial` command is available at all times, so that the user can specify which of the vanilla materials they want to use. The value of `useVanillaPortals` now determines which materials are permitted in that command: `true` = `PORTAL` or `ENDGATEWAY`, `false` = the whole enum.

Entities can't be teleported through End Gateway-based gates regardless of the value set with `/gate setentities`, purely because implementing that would require major changes to the way in which entities are currently teleported. Failure to do this properly would create opportunities to duplicate items by throwing them into gates. For now, there's simply an `EntityTeleportEvent` handler that cancels the teleportation event if it's triggered by an End Gateway block that's part of a gate, which prevents item duplication exploits and is at least consistent with the behavior of Nether Portal-based gates. I don't have a pressing need to address this for my own use case, but I might revisit it later.